### PR TITLE
Fix PhotoSwipe opening wrong photo on paginated albums

### DIFF
--- a/template/masonry.tpl
+++ b/template/masonry.tpl
@@ -11,13 +11,15 @@
 .masonry-thumb { border-radius: {$MASONRY_RADIUS|escape:'html'}px; }
 </style>
     <div class="masonry-gallery">
+            {assign var=mq_idx value=0+$START_ID}
             {foreach from=$thumbnails item=thumbnail}
                 <div class="masonry-thumb">
-                    <a href="{$thumbnail.URL}">
+                    <a href="{$thumbnail.URL}" data-index="{$mq_idx}">
                         {assign var=derivative value=$pwg->derivative($derivative_params, $thumbnail.src_image)}
                         <img draggable="false" src="{$derivative->get_url()}" alt="{$thumbnail.TN_ALT}" title="{$thumbnail.TN_TITLE}">
                     </a>
                 </div>
+            {assign var=mq_idx value=$mq_idx+1}
             {/foreach}
     </div>
 {/if}


### PR DESCRIPTION
## Problem

On any album with more than one page of thumbnails, clicking a thumbnail on page *N* opens the PhotoSwipe lightbox on the **photo at that same position on page 1**, not the photo you clicked. Only page 1 behaves correctly.

## Cause

Themes that wire PhotoSwipe on the index (e.g. `bootstrap_darkroom`) build the lightbox item list from the **entire album** and map a clicked thumbnail to its slide through a **global** `data-index` — `page-start-offset + position` — which is exactly what core's `thumbnails.tpl` emits:

```smarty
{assign var=idx value=0+$START_ID}
...
<a href="{$thumbnail.URL}" data-index="{$idx}">
```

The masonry template emitted anchors with **no `data-index`**, so the theme's `setupPhotoSwipe()` fell back to each thumbnail's *page-local* DOM position (`0..N-1`). On page 1 local == global, so it worked; on page 3 the local index (`0..79`) pointed into the first page of the global list → page 1's photos.

## Fix

Emit `data-index` on each masonry anchor as `$START_ID + position`, mirroring the native template. `$START_ID` is the page start offset (`0` when unset → correct single-page behaviour), and because each anchor carries its own global index the mapping is correct no matter how the thumbnails are visually arranged.

Three-line template change, no JS/PHP touched.